### PR TITLE
feat: limit keyboard view size with anchors + add pasteFromClipboard and addText helper functions

### DIFF
--- a/examples/basic/KeyboardExtension.tsx
+++ b/examples/basic/KeyboardExtension.tsx
@@ -1,5 +1,5 @@
 import { Button, StyleSheet, Text, View } from "react-native";
-import { addText, pasteFromClipboard } from "expo-keyboard-extension";
+import { addText } from "expo-keyboard-extension";
 export default function KeyboardExtension({ url }: { url: string }) {
   console.log("Keyboard!");
 
@@ -10,7 +10,6 @@ export default function KeyboardExtension({ url }: { url: string }) {
       >
         Changes?
       </Text>
-      <Button title="Paste" onPress={pasteFromClipboard} />
 
       <Button title="Add Text" onPress={() => addText("Hello World")} />
     </View>

--- a/examples/basic/KeyboardExtension.tsx
+++ b/examples/basic/KeyboardExtension.tsx
@@ -1,16 +1,18 @@
 import { Button, StyleSheet, Text, View } from "react-native";
-
+import { addText, pasteFromClipboard } from "expo-keyboard-extension";
 export default function KeyboardExtension({ url }: { url: string }) {
-  console.log("Keyboard!")
+  console.log("Keyboard!");
 
-  
   return (
     <View style={styles.container}>
       <Text
         style={{ fontFamily: "Inter-Black", fontSize: 24, marginBottom: 10 }}
       >
-        Changes? 
+        Changes?
       </Text>
+      <Button title="Paste" onPress={pasteFromClipboard} />
+
+      <Button title="Add Text" onPress={() => addText("Hello World")} />
     </View>
   );
 }
@@ -18,9 +20,7 @@ export default function KeyboardExtension({ url }: { url: string }) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    borderRadius: 20,
     backgroundColor: "#FAF8F5",
-    alignItems: "center",
     justifyContent: "center",
     padding: 30,
   },

--- a/examples/basic/ios/basicKeyboardExtension/KeyboardExtensionViewController.swift
+++ b/examples/basic/ios/basicKeyboardExtension/KeyboardExtensionViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import React
+import SwiftUI
 
 class KeyboardViewController: UIInputViewController {
   
@@ -66,6 +67,11 @@ class KeyboardViewController: UIInputViewController {
         self?.close()
       }
     }
+    NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "addKey"), object: nil, queue: nil) { notification in
+        if let text = notification.object as? String {
+            self.textDocumentProxy.insertText(text)
+        }
+    }
   }
   
   private func cleanupAfterClose() {
@@ -93,7 +99,8 @@ class KeyboardViewController: UIInputViewController {
       height: withHeight ?? self.view.bounds.height
     )
     rootView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    self.view.addSubview(rootView)
+
+    view.addKeyboardSubview(rootView, withHeight: withHeight ?? self.view.bounds.height)
   }
   
   private func jsCodeLocation() -> URL? {
@@ -111,5 +118,25 @@ class KeyboardViewController: UIInputViewController {
     let blue = dict["blue"] ?? 255.0
     let alpha = dict["alpha"] ?? 1
     return UIColor(red: red / 255.0, green: green / 255.0, blue: blue / 255.0, alpha: alpha)
+  }
+}
+
+
+extension UIView {
+  func addKeyboardSubview(_ subview: UIView, withHeight: CGFloat) {
+    subview.translatesAutoresizingMaskIntoConstraints = false
+      
+      subview.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      subview.backgroundColor = UIColor.systemBlue
+             
+   
+    addSubview(subview)
+    NSLayoutConstraint.activate([
+      subview.leftAnchor.constraint(equalTo: leftAnchor),
+      subview.rightAnchor.constraint(equalTo: rightAnchor),
+      subview.topAnchor.constraint(equalTo: topAnchor),
+      subview.bottomAnchor.constraint(equalTo: bottomAnchor),
+      subview.heightAnchor.constraint(equalToConstant: withHeight) 
+    ])
   }
 }

--- a/ios/ExpoKeyboardExtensionModule.swift
+++ b/ios/ExpoKeyboardExtensionModule.swift
@@ -8,14 +8,6 @@ public class ExpoKeyboardExtensionModule: Module {
       NotificationCenter.default.post(name: NSNotification.Name("close"), object: nil)
     }
 
-    Function("pasteFromClipboard") { () in
-      let clipboard = UIPasteboard.general
-        
-      if let clipboardValue = clipboard.string {           
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "addKey"), object: clipboardValue)
-      }
-    }
-
     Function("addText") { (text: String) -> Void in
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: "addKey"), object: text)
     }

--- a/ios/ExpoKeyboardExtensionModule.swift
+++ b/ios/ExpoKeyboardExtensionModule.swift
@@ -7,5 +7,17 @@ public class ExpoKeyboardExtensionModule: Module {
     Function("close") { () in
       NotificationCenter.default.post(name: NSNotification.Name("close"), object: nil)
     }
+
+    Function("pasteFromClipboard") { () in
+      let clipboard = UIPasteboard.general
+        
+      if let clipboardValue = clipboard.string {           
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "addKey"), object: clipboardValue)
+      }
+    }
+
+    Function("addText") { (text: String) -> Void in
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "addKey"), object: text)
+    }
   }
 }

--- a/plugin/src/withKeyboardExtensionInfoPlist.ts
+++ b/plugin/src/withKeyboardExtensionInfoPlist.ts
@@ -9,7 +9,6 @@ import {
   getKeyboardExtensionName,
 } from "./index";
 
-
 export const withKeyboardExtensionInfoPlist: ConfigPlugin<{
   fonts: string[];
   backgroundColor?: BackgroundColor;
@@ -62,9 +61,10 @@ export const withKeyboardExtensionInfoPlist: ConfigPlugin<{
           IsASCIICapable: false,
           PrefersRightToLeft: false,
           PrimaryLanguage: "en-US",
-          RequestsOpenAccess: false,
+          RequestsOpenAccess: true,
         },
-        NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).KeyboardViewController",
+        NSExtensionPrincipalClass:
+          "$(PRODUCT_MODULE_NAME).KeyboardViewController",
         NSExtensionPointIdentifier: "com.apple.keyboard-service",
       },
       KeyboardExtensionBackgroundColor: backgroundColor,

--- a/plugin/swift/KeyboardExtensionViewController.swift
+++ b/plugin/swift/KeyboardExtensionViewController.swift
@@ -126,9 +126,7 @@ extension UIView {
   func addKeyboardSubview(_ subview: UIView, withHeight: CGFloat) {
     subview.translatesAutoresizingMaskIntoConstraints = false
       
-      subview.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-      subview.backgroundColor = UIColor.systemBlue
-             
+    subview.autoresizingMask = [.flexibleWidth, .flexibleHeight]         
    
     addSubview(subview)
     NSLayoutConstraint.activate([

--- a/plugin/swift/KeyboardExtensionViewController.swift
+++ b/plugin/swift/KeyboardExtensionViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import React
+import SwiftUI
 
 class KeyboardViewController: UIInputViewController {
   
@@ -66,6 +67,11 @@ class KeyboardViewController: UIInputViewController {
         self?.close()
       }
     }
+    NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "addKey"), object: nil, queue: nil) { notification in
+        if let text = notification.object as? String {
+            self.textDocumentProxy.insertText(text)
+        }
+    }
   }
   
   private func cleanupAfterClose() {
@@ -93,7 +99,8 @@ class KeyboardViewController: UIInputViewController {
       height: withHeight ?? self.view.bounds.height
     )
     rootView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    self.view.addSubview(rootView)
+
+    view.addKeyboardSubview(rootView, withHeight: withHeight ?? self.view.bounds.height)
   }
   
   private func jsCodeLocation() -> URL? {
@@ -111,5 +118,25 @@ class KeyboardViewController: UIInputViewController {
     let blue = dict["blue"] ?? 255.0
     let alpha = dict["alpha"] ?? 1
     return UIColor(red: red / 255.0, green: green / 255.0, blue: blue / 255.0, alpha: alpha)
+  }
+}
+
+
+extension UIView {
+  func addKeyboardSubview(_ subview: UIView, withHeight: CGFloat) {
+    subview.translatesAutoresizingMaskIntoConstraints = false
+      
+      subview.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      subview.backgroundColor = UIColor.systemBlue
+             
+   
+    addSubview(subview)
+    NSLayoutConstraint.activate([
+      subview.leftAnchor.constraint(equalTo: leftAnchor),
+      subview.rightAnchor.constraint(equalTo: rightAnchor),
+      subview.topAnchor.constraint(equalTo: topAnchor),
+      subview.bottomAnchor.constraint(equalTo: bottomAnchor),
+      subview.heightAnchor.constraint(equalToConstant: withHeight) 
+    ])
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,6 @@ export function close(): void {
   return ExpoKeyboardExtensionModule.close();
 }
 
-export function pasteFromClipboard(): void {
-  return ExpoKeyboardExtensionModule.pasteFromClipboard();
-}
-
 export function addText(text: string): void {
   return ExpoKeyboardExtensionModule.addText(text);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,14 @@ export function close(): void {
   return ExpoKeyboardExtensionModule.close();
 }
 
+export function pasteFromClipboard(): void {
+  return ExpoKeyboardExtensionModule.pasteFromClipboard();
+}
+
+export function addText(text: string): void {
+  return ExpoKeyboardExtensionModule.addText(text);
+}
+
 export interface IExtensionPreprocessingJS {
   run: (args: { completionFunction: (data: unknown) => void }) => void;
   finalize: (args: unknown) => void;


### PR DESCRIPTION
I've added a limitation to the keyboard view and included some helpers

before / after

![2024-08-11 14 35 32](https://github.com/user-attachments/assets/77b362e3-0498-48b0-bad6-fbcc3c71f88b)
![2024-08-11 14 18 56](https://github.com/user-attachments/assets/292639a8-d949-4d89-b874-5c4d81d0c62c)
